### PR TITLE
fix horn arguments are shared between guilds

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -81,14 +81,8 @@ client.on("message", async (message: Message) => {
   let curPrefix = defaultPrefix;
   try {
     if (message.channel.type !== "dm") {
-      if (!guilds.has(message.guild.id)) {
-        const guildData = await initGuildData(message.guild);
-        const argList = Array.from(guildData.audioAliases.keys());
-        commands.get("horn").argList = argList.length > 0 ? argList : null;
-        curPrefix = guildData.prefix;
-      } else {
-        curPrefix = guilds.get(message.guild.id).prefix;
-      }
+      if (!guilds.has(message.guild.id)) await initGuildData(message.guild);
+      curPrefix = guilds.get(message.guild.id).prefix;
     }
   } catch (error) {
     console.error(error);

--- a/commands/sound/horn.ts
+++ b/commands/sound/horn.ts
@@ -1,4 +1,3 @@
-import fs from "fs";
 import { Command, Message } from "discord.js";
 import {
   HORN_PLAYING_MUSIC,
@@ -13,10 +12,11 @@ import { getDefaultAudios } from "../../util/getDefaultAudios";
 export = <Command>{
   name: "horn",
   aliases: ["h", "say"],
-  description: "Play a sound. Ex. [~horn ww].",
+  description: "Play a sound.",
   usage: "[audio name]",
   guildOnly: true,
   args: Args.required,
+  argList: getDefaultAudios(),
   async execute(message: Message, args: string[]) {
     const error = checkUserInAChannel(message);
     if (error) return message.channel.send(error.toBold());

--- a/commands/utility/help.ts
+++ b/commands/utility/help.ts
@@ -2,7 +2,6 @@ import fs from "fs";
 import Discord, { Command, Message } from "discord.js";
 import { commands, guilds } from "../../app";
 import { awaitDone } from "../../util/awaitDone";
-import { getDefaultAudios } from "../../util/getDefaultAudios";
 
 require("dotenv").config();
 const defaultPrefix = process.env.PREFIX;
@@ -95,7 +94,11 @@ export = <Command>{
       });
     if (command.argList) {
       let argList = command.argList;
-      if (command.name === "horn") argList = argList.concat(getDefaultAudios());
+
+      if (command.name === "horn" && message.channel.type !== "dm")
+        argList = argList.concat(
+          Array.from(guilds.get(message.guild.id).audioAliases.keys())
+        );
 
       argList = argList.map((arg) => arg.toInlineCodeBg());
       data.push({ name: `Arguments:`, value: `${argList.join(" ")}` });


### PR DESCRIPTION
Only the default audio names are stored in the command. 
When not in DMs, guild-specific arguments for the `horn` command are fetched from the `guilds` by id.